### PR TITLE
Revert "FIPS Fix"

### DIFF
--- a/ash-windows/deltafiles/GpoDelta.txt
+++ b/ash-windows/deltafiles/GpoDelta.txt
@@ -27,3 +27,12 @@ Computer
 System\CurrentControlSet\Control\SecurityProviders\WDigest
 UseLogonCredential
 DWORD:0
+
+;As of 20150320, the AWS SDK for .NET has an open issue that makes it non-compliant
+;with FIPS requirements, https://github.com/aws/aws-sdk-net/issues/48
+;The delta policy will disable the security setting enforcing use of FIPS compliant
+;algorithms until this issue is resolved
+Computer
+System\CurrentControlSet\Control\Lsa\FIPSAlgorithmPolicy
+Enabled
+DWORD:0


### PR DESCRIPTION
Reverts lorengordon/ash-windows-formula#13. The AWS Windows AMI does not yet include the patched version of the .NET SDK. When the AMI is updated, this patch will be re-applied.